### PR TITLE
Implement operation queue for file logger

### DIFF
--- a/DailyFileLogger/DailyFileLogger.csproj
+++ b/DailyFileLogger/DailyFileLogger.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\QueueLibrary\QueueLibrary.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/DailyFileLogger/Providers/DailyFileLoggerProvider.cs
+++ b/DailyFileLogger/Providers/DailyFileLoggerProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using DailyFileLogger.Core;
+using QueueLibrary.Core;
 
 namespace DailyFileLogger.Providers
 {
@@ -10,6 +11,7 @@ namespace DailyFileLogger.Providers
     public class DailyFileLoggerProvider : ILoggerProvider
     {
         private readonly IHostEnvironment _env;
+        private readonly OperationQueue _queue = new();
 
         public DailyFileLoggerProvider(IHostEnvironment env)
         {
@@ -17,11 +19,11 @@ namespace DailyFileLogger.Providers
         }
 
         public ILogger CreateLogger(string categoryName)
-            => new DailyFileLoggers(categoryName, _env);
+            => new DailyFileLoggers(categoryName, _env, _queue);
 
         public void Dispose()
         {
-            // 沒有要釋放的資源
+            _queue.DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
     }
 }

--- a/MoneyMinder/Program.cs
+++ b/MoneyMinder/Program.cs
@@ -7,10 +7,10 @@ namespace MoneyMinder
     {
         public static void Main(string[] args)
         {
-            // Register custom services
-            builder.Services.AddTransient<MoneyMinder.Services.ILogService, MoneyMinder.Services.LogService>();
             // 建立 WebApplicationBuilder
             var builder = WebApplication.CreateBuilder(args);
+            // Register custom services
+            builder.Services.AddTransient<MoneyMinder.Services.ILogService, MoneyMinder.Services.LogService>();
 
             #region 新增Logging使用方式
             //-------------------------新增Logging註冊方式---------------------------


### PR DESCRIPTION
## Summary
- use `OperationQueue` in `DailyFileLoggers` so log writes are queued
- manage a single `OperationQueue` instance in `DailyFileLoggerProvider`
- reference `QueueLibrary` from logger project
- minor fix to program initialization order

## Testing
- `dotnet build MoneyMinder.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5bedc7488330b7e8726a26af8c8c